### PR TITLE
Always include line break node

### DIFF
--- a/Sources/Apodimark/InlineParsing/DelimiterArray/ProcessText.swift
+++ b/Sources/Apodimark/InlineParsing/DelimiterArray/ProcessText.swift
@@ -68,13 +68,8 @@ struct TextInlineNodeIterator <View: BidirectionalCollection, Codec: MarkdownPar
             }
         }()
         
-        if i == text.endIndex-1 {
-            let adjustedEnd = linebreak == .backslashHardbreak ? view.index(after: end) : end
-            return TextInlineNode(kind: .text, start: indices.lowerBound, end: adjustedEnd)
-        } else {
-            queuedTextInline = TextInlineNode(kind: linebreak == .softbreak ? .softbreak : .hardbreak, start: end, end: indices.upperBound)
-            return TextInlineNode(kind: .text, start: indices.lowerBound, end: end)
-        }
+      queuedTextInline = TextInlineNode(kind: linebreak == .softbreak ? .softbreak : .hardbreak, start: end, end: indices.upperBound)
+      return TextInlineNode(kind: .text, start: indices.lowerBound, end: end)
     }
 }
 


### PR DESCRIPTION
Apodimark was trying to be helpful by not providing a new line node in the tree if it came at the end of a string. We need this new line node right now so you can still create multi-line items, and soon to use the new line node as an indicator that we need to create a new item.

At this point I'm still keeping with the coding style of Apodimark, but if we don't expect to take frequent updates from the official repository we could lint and format the project to our standards (which would cause horrible merges otherwise).