### PR TITLE
Encode emphasis type information in the AST

### DIFF
--- a/Sources/Apodimark/Apodimark.swift
+++ b/Sources/Apodimark/Apodimark.swift
@@ -58,6 +58,13 @@ extension String: ReferenceDefinitionProtocol {
     public init(string: String) { self = string }
 }
 
+public enum EmphasisType {
+    case bold
+    case italic
+    case underline
+    case strikethrough
+}
+
 public struct ParagraphBlock <View: BidirectionalCollection, RefDef> {
     public let text: [MarkdownInline<View, RefDef>]
 }
@@ -119,6 +126,7 @@ public struct ReferenceInline <View: BidirectionalCollection, RefDef> {
 
 public struct EmphasisInline <View: BidirectionalCollection, RefDef> {
     public let level: Int
+    public let type: EmphasisType
     public let content: [MarkdownInline<View, RefDef>]
     public let markers: (Range<View.Index>, Range<View.Index>)
 }
@@ -299,12 +307,13 @@ extension MarkdownParser {
                     )
                     nodes.append(.monospacedText(inline))
                     
-                case .emphasis(let level):
+                case let .emphasis(level, type):
                     let startMarkers = n.start ..< view.index(n.start, offsetBy: numericCast(level))
                     let endMarkers = view.index(n.end, offsetBy: numericCast(-level)) ..< n.end
                     
                     let inline = EmphasisInline(
                         level: numericCast(level),
+                        type: type,
                         content: children.map(makeFinalInlineNodeTree) ?? [],
                         markers: (startMarkers, endMarkers)
                     )

--- a/Sources/Apodimark/InlineParsing/DelimiterArray/ProcessEmphasis.swift
+++ b/Sources/Apodimark/InlineParsing/DelimiterArray/ProcessEmphasis.swift
@@ -65,7 +65,7 @@ extension MarkdownParser {
             delimiters[openingDelIdx] = nil
             delimiters[closingDelIdx] = nil
             nodes.append(.init(
-                kind: .emphasis(l1),
+                kind: .emphasis(l1, .bold /*XXX*/),
                 start: view.index(openingDel.idx, offsetBy: numericCast(-l1)),
                 end: closingDel.idx
             ))
@@ -78,7 +78,7 @@ extension MarkdownParser {
             let endOffset = -(l2 - l1)
             
             nodes.append(.init(
-                kind: .emphasis(l1),
+                kind: .emphasis(l1, .bold /*XXX*/),
                 start: view.index(openingDel.idx, offsetBy: numericCast(startOffset)),
                 end: view.index(closingDel.idx, offsetBy: numericCast(endOffset))
             ))
@@ -91,7 +91,7 @@ extension MarkdownParser {
             delimiters[openingDelIdx]!.kind = .emph(kind, state1, l1 - l2)
             
             nodes.append(.init(
-                kind: .emphasis(l2),
+                kind: .emphasis(l2, .bold/*XXX*/),
                 start: view.index(openingDel.idx, offsetBy: numericCast(-l2)),
                 end: closingDel.idx
             ))

--- a/Sources/Apodimark/InlineParsing/InlineNode.swift
+++ b/Sources/Apodimark/InlineParsing/InlineNode.swift
@@ -22,7 +22,7 @@ enum InlineNode <View: BidirectionalCollection, RefDef: ReferenceDefinitionProto
 enum NonTextInlineNodeKind <View: BidirectionalCollection, RefDef: ReferenceDefinitionProtocol> {
     indirect case reference(ReferenceKind, title: Range<View.Index>, definition: RefDef)
     case code(Int32)
-    case emphasis(Int32)
+    case emphasis(Int32, EmphasisType)
     case escapingBackslash
 }
 
@@ -51,7 +51,7 @@ struct NonTextInlineNode <View: BidirectionalCollection, RefDef: ReferenceDefini
             return title
         case .code(let l):
             return view.index(start, offsetBy: numericCast(l)) ..< view.index(end, offsetBy: numericCast(-l))
-        case .emphasis(let l):
+        case let .emphasis(l, t):
             return view.index(start, offsetBy: numericCast(l)) ..< view.index(end, offsetBy: numericCast(-l))
         case .escapingBackslash:
             return start ..< start


### PR DESCRIPTION
This PR sets up the type of emphasis in the public AST node, as well as makes sure we actually capture it. In the next PR, we'll implement the rest of the types (i.e. strike + underline)