### PR TITLE
Parse indented, empty lines

### DIFF
--- a/Apodimark.xcodeproj/project.pbxproj
+++ b/Apodimark.xcodeproj/project.pbxproj
@@ -929,6 +929,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = land.loic.ApodimarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -947,6 +948,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = land.loic.ApodimarkTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/Sources/Apodimark/Apodimark.swift
+++ b/Sources/Apodimark/Apodimark.swift
@@ -67,6 +67,7 @@ public enum EmphasisType {
 
 public struct ParagraphBlock <View: BidirectionalCollection, RefDef> {
     public let text: [MarkdownInline<View, RefDef>]
+    public let indent: Int
 }
 
 public struct HeaderBlock <View: BidirectionalCollection, RefDef> {
@@ -211,7 +212,7 @@ extension MarkdownParser {
             
         case let .paragraph(p):
             let inlines = makeFinalInlineNodeTree(from: parseInlines(p.text).makeBreadthFirstIterator())
-            let block = ParagraphBlock(text: inlines)
+            let block = ParagraphBlock(text: inlines, indent: p.indent)
             return .paragraph(block)
             
             

--- a/Sources/Apodimark/BlockParsing/BlockAST.swift
+++ b/Sources/Apodimark/BlockParsing/BlockAST.swift
@@ -12,10 +12,12 @@ enum BlockNode <View: BidirectionalCollection, RefDef: ReferenceDefinitionProtoc
 }
 
 final class ParagraphNode <View: BidirectionalCollection> {
+    var indent: Int
     var text: [Range<View.Index>]
     var closed: Bool
-    init(text: [Range<View.Index>]) {
+    init(text: [Range<View.Index>], indent: Int) {
         (self.text, self.closed) = (text, false)
+        self.indent = indent
     }
 }
 

--- a/Sources/Apodimark/BlockParsing/BlockParsing.swift
+++ b/Sources/Apodimark/BlockParsing/BlockParsing.swift
@@ -71,7 +71,7 @@ extension MarkdownParser {
         
         let addResult = last.map{ add(line: line, to: $0, depthLevel: .root) } ?? .failure
         
-        if case .failure = addResult, !line.kind.isEmpty() {
+        if case .failure = addResult {
             _ = appendStrand(from: line, level: .root)
         }
     }

--- a/Sources/Apodimark/DataStructures/Tree.swift
+++ b/Sources/Apodimark/DataStructures/Tree.swift
@@ -273,7 +273,7 @@ extension MarkdownParser {
             appendStrand(line: rest, previousEnd: previousEnd)
             
         case .text:
-            append(.paragraph(.init(text: [line.indices])))
+            append(.paragraph(.init(text: [line.indices], indent: line.indent.level)))
             
         case .header(let text, let level):
             let startHashes = line.indices.lowerBound ..< view.index(line.indices.lowerBound, offsetBy: numericCast(level))
@@ -315,7 +315,7 @@ extension MarkdownParser {
             append(.thematicBreak(.init(span: line.indices)))
             
         case .empty:
-            append(.paragraph(.init(text: [])))
+            append(.paragraph(.init(text: [], indent: line.indent.level)))
             
         case let .reference(title, definition):
             append(.referenceDefinition(.init(title: title, definition: definition)))

--- a/test-files/commonmark-conformance/184-result.txt
+++ b/test-files/commonmark-conformance/184-result.txt
@@ -1,1 +1,1 @@
-Document { Paragraph(aaa), Header(1, aaa), }
+Document { Paragraph(), Paragraph(aaa), Paragraph(), Header(1, aaa), Paragraph(), }

--- a/test-files/commonmark-conformance/507-result.txt
+++ b/test-files/commonmark-conformance/507-result.txt
@@ -1,1 +1,1 @@
-Document { Paragraph([ref: bar(/url1)]), }
+Document { Paragraph([ref: foo(/url1)]: /url2), Paragraph([ref: bar(/url1)]), }

--- a/test-files/commonmark-conformance/82-result.txt
+++ b/test-files/commonmark-conformance/82-result.txt
@@ -1,1 +1,1 @@
-Document { Code[foo], }
+Document { Paragraph(), Code[foo], }


### PR DESCRIPTION
You may have noticed pressing spacebar on a line does nothing. That's because Apodimark wasn't parsing an indented, empty line. In this PR, we expose the indent, and return empty, indented lines. This also updates the corresponding unit-tests, and ensures they're built with swift 4.0.

This resolves #10 