### PR TITLE
Don't parse code blocks

### DIFF
--- a/Sources/Apodimark/DataStructures/Tree.swift
+++ b/Sources/Apodimark/DataStructures/Tree.swift
@@ -259,14 +259,6 @@ extension MarkdownParser {
             blockTree.buffer.append(.init(data: block, end: previousEnd))
         }
         
-        guard line.indent.level < TAB_INDENT else {
-            var newLine = line
-            newLine.indent.level -= TAB_INDENT
-            restoreIndentInLine(&newLine)
-            append(.code(.init(text: [newLine.indices], trailingEmptyLines: [])))
-            return
-        }
-        
         switch line.kind {
         case .quote(let rest):
             append(.quote(.init(firstMarker: line.indices.lowerBound)))


### PR DESCRIPTION
This impedes our ability to indent code past four spaces. We can re-enable this once we support code blocks in the editor.