### PR TITLE
Only parse a header if it's a # followed by a space

### DIFF
--- a/Sources/Apodimark/BlockParsing/LineLexer.swift
+++ b/Sources/Apodimark/BlockParsing/LineLexer.swift
@@ -212,7 +212,7 @@ extension MarkdownParser {
             try scanner.popWhile { token in
 
                 guard case let token? = token else {
-                    throw HeaderParsingError.emptyHeader(level)
+                    throw HeaderParsingError.notAHeader
                 }
 
                 switch token {
@@ -225,7 +225,7 @@ extension MarkdownParser {
                     return .stop
 
                 case Codec.linefeed:
-                    throw HeaderParsingError.emptyHeader(level)
+                    throw HeaderParsingError.notAHeader
 
                 default:
                     throw HeaderParsingError.notAHeader


### PR DESCRIPTION
We don't want headers parsed immediately after a # is entered; instead, wait for a space after that.