### PR TITLE
Update Package.swift for Swift 4.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,31 @@
+// swift-tools-version:4.2
+// The swift-tools-version declares the minimum version of Swift required to
+// build this package.
 
 import PackageDescription
 
-let package = Package(name: "Apodimark")
+let package = Package(
+  name: "Apodimark",
+  products: [
+    // Products define the executables and libraries produced by a package, and
+    // make them visible to other packages.
+    .library(
+      name: "Apodimark",
+      targets: ["Apodimark"]
+    ),
+  ],
+  dependencies: [
+    // Dependencies declare other packages that this package depends on.
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package. A target can define
+    // a module or a test suite.
+    // Targets can depend on other targets in this package, and on products in
+    // packages which this package depends on.
+    .target(
+      name: "Apodimark",
+      dependencies: []
+    ),
+  ]
+)
+

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .library(
       name: "Apodimark",
       targets: ["Apodimark"]
-    ),
+    )
   ],
   dependencies: [
     // Dependencies declare other packages that this package depends on.
@@ -25,7 +25,6 @@ let package = Package(
     .target(
       name: "Apodimark",
       dependencies: []
-    ),
+    )
   ]
 )
-


### PR DESCRIPTION
Hi @JasonConn and @rhettdickson,

I appreciate you keeping this project alive! I'm seeing warnings when pulling this repo with SwiftPM:

>warning: PackageDescription API v3 is deprecated and will be removed in the future; used by package(s): Apodimark

This PR updates `Package.swift` to [the recent v4.2](https://github.com/apple/swift-evolution/blob/master/proposals/0209-package-manager-swift-lang-version-update.md), which I hope can be merged, but please let me know if anything else needs to be updated here.

Thanks!